### PR TITLE
backend WIP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 FLASK_SECRET_KEY=your-flask-secret-key
 OPENAI_API_KEY=your-openai-api-key
 MONGODB_URI=your-mongodb-connection-uri
+MONGODB_URI_TEST=your-test-mongodb-connection-uri
 FIRST_TIME_USER_EMAIL=your-dev-forced-onboarding@email.com
 ADMIN_EMAILS=admin1@email.com,admin2@email.com
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Edit `.env` with your credentials. Required variables:
 | `FLASK_SECRET_KEY` | Random secret for session signing |
 | `OPENAI_API_KEY` | OpenAI API key |
 | `MONGODB_URI` | MongoDB Atlas connection string |
+| `MONGODB_URI_TEST` | Separate MongoDB connection string for tests |
 | `ADMIN_EMAILS` | Comma-separated admin email addresses |
 | `RESEND_API_KEY` | Resend API key for password reset emails |
 | `FROM_EMAIL` | Sender address for outbound emails |
@@ -64,11 +65,11 @@ Server starts at `http://localhost:5000`. The frontend expects `VITE_BACKEND_URL
 
 ## Testing
 
-Tests run against a real MongoDB instance. Your `MONGODB_URI` **must** point to a database whose name contains `"test"` (e.g. `quantaied_test`). The test cleanup fixture will refuse to run against any other database to prevent accidental data loss.
+Tests run against a real MongoDB instance using the `MONGODB_URI_TEST` environment variable, which is completely separate from the production `MONGODB_URI`. This prevents any risk of accidentally modifying production data.
 
 ```bash
-# 1. Set MONGODB_URI to a test database in your .env
-#    MONGODB_URI=mongodb+srv://..../quantaied_test?retryWrites=true
+# 1. Set MONGODB_URI_TEST to a test database in your .env
+#    MONGODB_URI_TEST=mongodb+srv://..../quantaied_test?retryWrites=true
 
 # 2. Run tests
 uv run pytest tests/ -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 """
 Shared test fixtures.
 
-Uses a dedicated MongoDB Atlas *test* database for integration tests. The database
-name must include 'test' to avoid accidentally running against dev or production
-data. A dedicated test prefix is also used for user emails as an extra safeguard.
+Uses a dedicated MongoDB test database via MONGODB_URI_TEST to isolate tests
+from dev/production data. A dedicated test prefix is used for user emails as
+an extra safeguard.
 """
 
 import os
@@ -13,6 +13,37 @@ import pytest
 
 # Ensure the project root is importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# ---------------------------------------------------------------------------
+# Override database.mongo.db with a test-only connection BEFORE the Flask app
+# (and any route/service modules) are imported.  This ensures every module that
+# does ``from database.mongo import db`` gets the test database.
+# ---------------------------------------------------------------------------
+from dotenv import load_dotenv
+
+load_dotenv()
+
+_test_uri = os.getenv("MONGODB_URI_TEST", "")
+if not _test_uri.strip():
+    raise RuntimeError(
+        "MONGODB_URI_TEST is not set. Tests require a dedicated test MongoDB URI. "
+        "Set MONGODB_URI_TEST in your .env file."
+    )
+
+from pymongo.errors import ConfigurationError  # noqa: E402
+from pymongo.mongo_client import MongoClient  # noqa: E402
+
+_test_client = MongoClient(_test_uri)
+try:
+    _test_db = _test_client.get_default_database()
+except ConfigurationError:
+    _test_db = _test_client.get_database("quantaied_test")
+
+# Importing database.mongo triggers the production client to be created,
+# but we immediately replace db with our test database.
+import database.mongo  # noqa: E402
+
+database.mongo.db = _test_db
 
 
 TEST_USER_PREFIX = "_test_"
@@ -43,12 +74,4 @@ def client(app):
 def cleanup_test_users():
     """Remove any test users created during the test."""
     yield
-    from database.mongo import db
-
-    db_name = str(getattr(db, "name", "")).lower()
-    if "test" not in db_name:
-        raise RuntimeError(
-            f"Refusing to run cleanup_test_users against non-test database '{db_name}'. "
-            "Ensure your MONGODB_URI points at a test database whose name includes 'test'."
-        )
-    db.users.delete_many({"user_id": {"$regex": f"^{TEST_USER_PREFIX}"}})
+    database.mongo.db.users.delete_many({"user_id": {"$regex": f"^{TEST_USER_PREFIX}"}})


### PR DESCRIPTION
---

🧪 This PR introduces a dedicated test database configuration by adding a separate `MONGODB_URI_TEST` environment variable, improving test isolation and preventing accidental data corruption in production databases. The changes include updating environment configuration, documentation, and test setup to use a completely separate MongoDB instance for testing.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Environment Configuration**: Added `MONGODB_URI_TEST` variable to `.env.example` for dedicated test database connection
- **Documentation Updates**: Updated README.md to reflect the new test database approach and removed the previous requirement for database names to contain "test"
- **Test Infrastructure**: Completely refactored `tests/conftest.py` to override the database connection before Flask app initialization, ensuring all modules use the test database
- **Safety Improvements**: Removed the database name validation logic that previously required "test" in the database name, replacing it with a cleaner separation approach

### Technical Implementation
```mermaid
flowchart TD
    A[Test Execution Starts] --> B[Load MONGODB_URI_TEST from .env]
    B --> C{Test URI Available?}
    C -->|No| D[Raise RuntimeError]
    C -->|Yes| E[Create Test MongoDB Client]
    E --> F[Override database.mongo.db]
    F --> G[Import Flask App & Routes]
    G --> H[Run Tests Against Test DB]
    H --> I[Cleanup Test Users]
    
    style E fill:#e1f5fe
    style F fill:#f3e5f5
    style H fill:#e8f5e8
```

### Impact
- **Test Safety**: Eliminates risk of accidentally running tests against production data by using completely separate database connections
- **Developer Experience**: Simplifies test setup by removing the need for specific database naming conventions
- **Code Maintainability**: Cleaner separation of concerns between production and test environments through dedicated configuration
- **Reliability**: Early validation ensures tests fail fast if test database is not properly configured

</details>

_Created with [Palmier](https://www.palmier.io)_